### PR TITLE
Fix incorrect stride when splitting up audio

### DIFF
--- a/datasets/music/preprocess.py
+++ b/datasets/music/preprocess.py
@@ -20,8 +20,8 @@ os.system("ffmpeg -f concat -safe 0 -i {}/preprocess_file_list.txt {}/preprocess
 length = float(subprocess.check_output('ffprobe -i {}/preprocess_all_audio.wav -show_entries format=duration -v quiet -of csv="p=0"'.format(OUTPUT_DIR), shell=True))
 
 # # Step 3: split the big file into 8-second chunks
-for i in xrange(int(length)//8 - 1):
-    os.system('ffmpeg -ss {} -t 8 -i {}/preprocess_all_audio.wav -ac 1 -ab 16k -ar 16000 {}/p{}.flac'.format(i, OUTPUT_DIR, OUTPUT_DIR, i))
+for i in xrange(int(length)//8):
+    os.system('ffmpeg -ss {} -t 8 -i {}/preprocess_all_audio.wav -ac 1 -ab 16k -ar 16000 {}/p{}.flac'.format(i * 8, OUTPUT_DIR, OUTPUT_DIR, i))
 
 # # Step 4: clean up temp files
 os.system('rm {}/preprocess_all_audio.wav'.format(OUTPUT_DIR))


### PR DESCRIPTION
Prior to this change the stride was 1 second and therefore only ~1/8th of the audio data is considered.

Minibatches could also contain audio segments with a large degree of overlap, which is wasteful.